### PR TITLE
No hard dependency on activities for full screen ads

### DIFF
--- a/adapter-cloudx/src/main/java/io/cloudx/adapter/cloudx/InterstitialFactory.kt
+++ b/adapter-cloudx/src/main/java/io/cloudx/adapter/cloudx/InterstitialFactory.kt
@@ -1,15 +1,18 @@
 package io.cloudx.adapter.cloudx
 
-import android.app.Activity
-import io.cloudx.sdk.internal.adapter.*
 import io.cloudx.sdk.Result
+import io.cloudx.sdk.internal.adapter.CloudXAdapterMetaData
+import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapter
+import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterFactory
+import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterListener
+import io.cloudx.sdk.internal.context.ContextProvider
 
 internal object InterstitialFactory :
     CloudXInterstitialAdapterFactory,
     CloudXAdapterMetaData by CloudXAdapterMetaData("cloudxdsp-version") {
 
     override fun create(
-        activity: Activity,
+        contextProvider: ContextProvider,
         placementId: String,
         bidId: String,
         adm: String,
@@ -17,7 +20,7 @@ internal object InterstitialFactory :
         listener: CloudXInterstitialAdapterListener,
     ): Result<CloudXInterstitialAdapter, String> = Result.Success(
         StaticBidInterstitial(
-            activity,
+            contextProvider.getContext(),
             adm,
             listener
         )

--- a/adapter-cloudx/src/main/java/io/cloudx/adapter/cloudx/RewardedInterstitialFactory.kt
+++ b/adapter-cloudx/src/main/java/io/cloudx/adapter/cloudx/RewardedInterstitialFactory.kt
@@ -1,15 +1,18 @@
 package io.cloudx.adapter.cloudx
 
-import android.app.Activity
-import io.cloudx.sdk.internal.adapter.*
 import io.cloudx.sdk.Result
+import io.cloudx.sdk.internal.adapter.CloudXAdapterMetaData
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapter
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterFactory
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterListener
+import io.cloudx.sdk.internal.context.ContextProvider
 
 internal object RewardedInterstitialFactory :
     CloudXRewardedInterstitialAdapterFactory,
     CloudXAdapterMetaData by CloudXAdapterMetaData("cloudx-version") {
 
     override fun create(
-        activity: Activity,
+        contextProvider: ContextProvider,
         placementId: String,
         bidId: String,
         adm: String,
@@ -17,7 +20,7 @@ internal object RewardedInterstitialFactory :
         listener: CloudXRewardedInterstitialAdapterListener
     ): Result<CloudXRewardedInterstitialAdapter, String> = Result.Success(
         StaticBidRewardedInterstitial(
-            activity,
+            contextProvider.getContext(),
             adm,
             listener
         )

--- a/adapter-cloudx/src/main/java/io/cloudx/adapter/cloudx/StaticBidInterstitial.kt
+++ b/adapter-cloudx/src/main/java/io/cloudx/adapter/cloudx/StaticBidInterstitial.kt
@@ -1,22 +1,22 @@
 package io.cloudx.adapter.cloudx
 
-import android.app.Activity
+import android.content.Context
+import io.cloudx.cd.staticrenderer.StaticFullscreenAd
 import io.cloudx.sdk.internal.FullscreenAd
-import io.cloudx.sdk.internal.adapter.CloudXAdLoadOperationAvailability
 import io.cloudx.sdk.internal.adapter.AlwaysReadyToLoadAd
+import io.cloudx.sdk.internal.adapter.CloudXAdLoadOperationAvailability
 import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapter
 import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterListener
-import io.cloudx.cd.staticrenderer.StaticFullscreenAd
 
 internal class StaticBidInterstitial(
-    activity: Activity,
+    context: Context,
     adm: String,
     listener: CloudXInterstitialAdapterListener
 ) : CloudXInterstitialAdapter,
     CloudXAdLoadOperationAvailability by AlwaysReadyToLoadAd {
 
     private val staticFullscreenAd = StaticFullscreenAd(
-        activity,
+        context,
         adm,
         object : FullscreenAd.Listener {
             override fun onLoad() {

--- a/adapter-cloudx/src/main/java/io/cloudx/adapter/cloudx/StaticBidRewardedInterstitial.kt
+++ b/adapter-cloudx/src/main/java/io/cloudx/adapter/cloudx/StaticBidRewardedInterstitial.kt
@@ -1,20 +1,22 @@
 package io.cloudx.adapter.cloudx
 
-import io.cloudx.sdk.internal.adapter.*
-
-import android.app.Activity
-import io.cloudx.sdk.internal.FullscreenAd
+import android.content.Context
 import io.cloudx.cd.staticrenderer.StaticFullscreenAd
+import io.cloudx.sdk.internal.FullscreenAd
+import io.cloudx.sdk.internal.adapter.AlwaysReadyToLoadAd
+import io.cloudx.sdk.internal.adapter.CloudXAdLoadOperationAvailability
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapter
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterListener
 
 internal class StaticBidRewardedInterstitial(
-    activity: Activity,
+    context: Context,
     adm: String,
     listener: CloudXRewardedInterstitialAdapterListener
 ) : CloudXRewardedInterstitialAdapter,
     CloudXAdLoadOperationAvailability by AlwaysReadyToLoadAd {
 
     private val staticFullscreenAd = StaticFullscreenAd(
-        activity,
+        context,
         adm,
         object : FullscreenAd.Listener {
             override fun onLoad() {

--- a/adapter-cloudx/src/main/java/io/cloudx/cd/staticrenderer/ExternalLinkHandler.kt
+++ b/adapter-cloudx/src/main/java/io/cloudx/cd/staticrenderer/ExternalLinkHandler.kt
@@ -1,6 +1,5 @@
 package io.cloudx.cd.staticrenderer
 
-import android.app.Activity
 import android.content.Context
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
@@ -9,9 +8,9 @@ fun interface ExternalLinkHandler {
     operator fun invoke(uri: String): Boolean
 }
 
-class ExternalLinkHandlerImpl(private val activity: Activity): ExternalLinkHandler {
+class ExternalLinkHandlerImpl(private val context: Context): ExternalLinkHandler {
     override fun invoke(uri: String): Boolean {
-        return activity.tryStartCustomTabs(uri)
+        return context.tryStartCustomTabs(uri)
     }
 }
 

--- a/adapter-cloudx/src/main/java/io/cloudx/cd/staticrenderer/StaticAdActivity.kt
+++ b/adapter-cloudx/src/main/java/io/cloudx/cd/staticrenderer/StaticAdActivity.kt
@@ -1,6 +1,6 @@
 package io.cloudx.cd.staticrenderer
 
-import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.Gravity
@@ -104,10 +104,12 @@ internal class StaticAdActivity : ComponentActivity() {
         }
 
         // Doesn't support parallel calls, not required though.
-        suspend fun show(activity: Activity, staticWebView: StaticWebView) {
+        suspend fun show(context: Context, staticWebView: StaticWebView) {
             try {
                 Companion.staticWebView = staticWebView
-                activity.startActivity(Intent(activity, StaticAdActivity::class.java))
+                val intent = Intent(context, StaticAdActivity::class.java)
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                context.startActivity(intent)
 
                 dismiss.first { it }
 

--- a/adapter-cloudx/src/main/java/io/cloudx/cd/staticrenderer/StaticFullscreenAd.kt
+++ b/adapter-cloudx/src/main/java/io/cloudx/cd/staticrenderer/StaticFullscreenAd.kt
@@ -1,6 +1,7 @@
 package io.cloudx.cd.staticrenderer
 
-import android.app.Activity
+import android.content.Context
+import io.cloudx.sdk.internal.FullscreenAd
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -8,21 +9,20 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import io.cloudx.sdk.internal.FullscreenAd
 
 fun StaticFullscreenAd(
-    activity: Activity,
+    context: Context,
     adm: String,
     listener: FullscreenAd.Listener?
 ): FullscreenAd<FullscreenAd.Listener> =
     StaticFullscreenAdImpl(
-        activity,
+        context,
         adm,
         listener
     )
 
 private class StaticFullscreenAdImpl(
-    private val activity: Activity,
+    private val context: Context,
     private val adm: String,
     override var listener: FullscreenAd.Listener?
 ) : FullscreenAd<FullscreenAd.Listener> {
@@ -30,7 +30,7 @@ private class StaticFullscreenAdImpl(
     private val scope = CoroutineScope(Dispatchers.Main)
 
     private val staticWebView: StaticWebView by lazy {
-        StaticWebView(activity, ExternalLinkHandlerImpl(activity))
+        StaticWebView(context, ExternalLinkHandlerImpl(context))
     }
 
     override fun load() {
@@ -58,7 +58,7 @@ private class StaticFullscreenAdImpl(
             }
 
             try {
-                StaticAdActivity.show(activity, staticWebView)
+                StaticAdActivity.show(context, staticWebView)
             } finally {
                 listener?.onComplete()
                 listener?.onHide()

--- a/adapter-google/src/main/java/io/cloudx/adapter/googleadmanager/GoogleAdHelper.java
+++ b/adapter-google/src/main/java/io/cloudx/adapter/googleadmanager/GoogleAdHelper.java
@@ -1,0 +1,22 @@
+package io.cloudx.adapter.googleadmanager;
+
+import android.app.Activity;
+
+import com.google.android.gms.ads.OnUserEarnedRewardListener;
+import com.google.android.gms.ads.admanager.AdManagerInterstitialAd;
+import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd;
+
+/**
+ * Helper class to bypass Kotlin nullability constraints when calling Google Ad APIs
+ * Google ads will still successfully show even with a null Activity
+ */
+public class GoogleAdHelper {
+
+    public static void showInterstitial(AdManagerInterstitialAd ad, Activity activity) {
+        ad.show(activity);
+    }
+
+    public static void showRewardedInterstitial(RewardedInterstitialAd ad, Activity activity, OnUserEarnedRewardListener listener) {
+        ad.show(activity, listener);
+    }
+}

--- a/adapter-google/src/main/java/io/cloudx/adapter/googleadmanager/InterstitialAdapter.kt
+++ b/adapter-google/src/main/java/io/cloudx/adapter/googleadmanager/InterstitialAdapter.kt
@@ -1,20 +1,20 @@
 package io.cloudx.adapter.googleadmanager
 
-import android.app.Activity
 import com.google.android.gms.ads.AdError
 import com.google.android.gms.ads.FullScreenContentCallback
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.admanager.AdManagerAdRequest
 import com.google.android.gms.ads.admanager.AdManagerInterstitialAd
 import com.google.android.gms.ads.admanager.AdManagerInterstitialAdLoadCallback
-import io.cloudx.sdk.internal.adapter.CloudXAdLoadOperationAvailability
 import io.cloudx.sdk.internal.adapter.AlwaysReadyToLoadAd
+import io.cloudx.sdk.internal.adapter.CloudXAdLoadOperationAvailability
 import io.cloudx.sdk.internal.adapter.CloudXAdapterError
 import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapter
 import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterListener
+import io.cloudx.sdk.internal.context.ContextProvider
 
 internal class InterstitialAdapter(
-    private val activity: Activity,
+    private val contextProvider: ContextProvider,
     private val adUnitId: String,
     private var listener: CloudXInterstitialAdapterListener?
 ) : CloudXInterstitialAdapter, CloudXAdLoadOperationAvailability by AlwaysReadyToLoadAd {
@@ -23,7 +23,7 @@ internal class InterstitialAdapter(
 
     override fun load() {
         AdManagerInterstitialAd.load(
-            activity,
+            contextProvider.getContext(),
             adUnitId,
             AdManagerAdRequest.Builder().build(),
             object : AdManagerInterstitialAdLoadCallback() {
@@ -71,7 +71,8 @@ internal class InterstitialAdapter(
             }
         }
 
-        ad.show(activity)
+        // Ad will still successfully show even with a null Activity
+        GoogleAdHelper.showInterstitial(ad, contextProvider.getActivityOrNull())
     }
 
     override fun destroy() {

--- a/adapter-google/src/main/java/io/cloudx/adapter/googleadmanager/InterstitialFactory.kt
+++ b/adapter-google/src/main/java/io/cloudx/adapter/googleadmanager/InterstitialFactory.kt
@@ -1,15 +1,18 @@
 package io.cloudx.adapter.googleadmanager
 
-import android.app.Activity
-import io.cloudx.sdk.internal.adapter.*
 import io.cloudx.sdk.Result
+import io.cloudx.sdk.internal.adapter.CloudXAdapterMetaData
+import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapter
+import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterFactory
+import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterListener
+import io.cloudx.sdk.internal.context.ContextProvider
 
 internal object InterstitialFactory :
     CloudXInterstitialAdapterFactory,
     CloudXAdapterMetaData by CloudXAdapterMetaData(AdManagerVersion) {
 
     override fun create(
-        activity: Activity,
+        contextProvider: ContextProvider,
         placementId: String,
         bidId: String,
         adm: String,
@@ -17,7 +20,7 @@ internal object InterstitialFactory :
         listener: CloudXInterstitialAdapterListener,
     ): Result<CloudXInterstitialAdapter, String> = Result.Success(
         InterstitialAdapter(
-            activity,
+            contextProvider,
             adUnitId = adm,
             listener
         )

--- a/adapter-google/src/main/java/io/cloudx/adapter/googleadmanager/RewardedInterstitialAdapter.kt
+++ b/adapter-google/src/main/java/io/cloudx/adapter/googleadmanager/RewardedInterstitialAdapter.kt
@@ -1,6 +1,5 @@
 package io.cloudx.adapter.googleadmanager
 
-import android.app.Activity
 import com.google.android.gms.ads.AdError
 import com.google.android.gms.ads.FullScreenContentCallback
 import com.google.android.gms.ads.LoadAdError
@@ -8,14 +7,15 @@ import com.google.android.gms.ads.OnUserEarnedRewardListener
 import com.google.android.gms.ads.admanager.AdManagerAdRequest
 import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
 import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAdLoadCallback
-import io.cloudx.sdk.internal.adapter.CloudXAdLoadOperationAvailability
 import io.cloudx.sdk.internal.adapter.AlwaysReadyToLoadAd
+import io.cloudx.sdk.internal.adapter.CloudXAdLoadOperationAvailability
 import io.cloudx.sdk.internal.adapter.CloudXAdapterError
 import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapter
 import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterListener
+import io.cloudx.sdk.internal.context.ContextProvider
 
 internal class RewardedInterstitialAdapter(
-    private val activity: Activity,
+    private val contextProvider: ContextProvider,
     private val adUnitId: String,
     private var listener: CloudXRewardedInterstitialAdapterListener?
 ) : CloudXRewardedInterstitialAdapter, CloudXAdLoadOperationAvailability by AlwaysReadyToLoadAd {
@@ -24,7 +24,7 @@ internal class RewardedInterstitialAdapter(
 
     override fun load() {
         RewardedInterstitialAd.load(
-            activity,
+            contextProvider.getContext(),
             adUnitId,
             AdManagerAdRequest.Builder().build(),
             object : RewardedInterstitialAdLoadCallback() {
@@ -72,7 +72,8 @@ internal class RewardedInterstitialAdapter(
             }
         }
 
-        ad.show(activity, OnUserEarnedRewardListener {
+        // Ad will still successfully show even with a null Activity
+        GoogleAdHelper.showRewardedInterstitial(ad, contextProvider.getActivityOrNull(), OnUserEarnedRewardListener {
             listener?.onEligibleForReward()
         })
     }

--- a/adapter-google/src/main/java/io/cloudx/adapter/googleadmanager/RewardedInterstitialFactory.kt
+++ b/adapter-google/src/main/java/io/cloudx/adapter/googleadmanager/RewardedInterstitialFactory.kt
@@ -1,15 +1,18 @@
 package io.cloudx.adapter.googleadmanager
 
-import android.app.Activity
-import io.cloudx.sdk.internal.adapter.*
 import io.cloudx.sdk.Result
+import io.cloudx.sdk.internal.adapter.CloudXAdapterMetaData
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapter
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterFactory
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterListener
+import io.cloudx.sdk.internal.context.ContextProvider
 
 internal object RewardedInterstitialFactory :
     CloudXRewardedInterstitialAdapterFactory,
     CloudXAdapterMetaData by CloudXAdapterMetaData(AdManagerVersion) {
 
     override fun create(
-        activity: Activity,
+        contextProvider: ContextProvider,
         placementId: String,
         bidId: String,
         adm: String,
@@ -17,7 +20,7 @@ internal object RewardedInterstitialFactory :
         listener: CloudXRewardedInterstitialAdapterListener
     ): Result<CloudXRewardedInterstitialAdapter, String> = Result.Success(
         RewardedInterstitialAdapter(
-            activity,
+            contextProvider,
             adUnitId = adm,
             listener
         )

--- a/adapter-meta/src/main/java/io/cloudx/adapter/meta/MetaInterstitialAdapter.kt
+++ b/adapter-meta/src/main/java/io/cloudx/adapter/meta/MetaInterstitialAdapter.kt
@@ -1,6 +1,5 @@
 package io.cloudx.adapter.meta
 
-import android.app.Activity
 import androidx.annotation.Keep
 import com.facebook.ads.Ad
 import com.facebook.ads.AdError
@@ -14,6 +13,7 @@ import io.cloudx.sdk.internal.adapter.CloudXAdapterMetaData
 import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapter
 import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterFactory
 import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterListener
+import io.cloudx.sdk.internal.context.ContextProvider
 
 @Keep
 internal object InterstitialFactory :
@@ -21,7 +21,7 @@ internal object InterstitialFactory :
     CloudXAdapterMetaData by CloudXAdapterMetaData(AudienceNetworkAdsVersion) {
 
     override fun create(
-        activity: Activity,
+        contextProvider: ContextProvider,
         placementId: String,
         bidId: String,
         adm: String,
@@ -29,7 +29,7 @@ internal object InterstitialFactory :
         listener: CloudXInterstitialAdapterListener,
     ): Result<CloudXInterstitialAdapter, String> = Result.Success(
         MetaInterstitialAdapter(
-            activity,
+            contextProvider,
             adUnitId = adm,
             listener
         )
@@ -37,7 +37,7 @@ internal object InterstitialFactory :
 }
 
 internal class MetaInterstitialAdapter(
-    private val activity: Activity,
+    private val contextProvider: ContextProvider,
     private val adUnitId: String,
     private var listener: CloudXInterstitialAdapterListener?
 ) : CloudXInterstitialAdapter, CloudXAdLoadOperationAvailability by AlwaysReadyToLoadAd {
@@ -53,7 +53,7 @@ internal class MetaInterstitialAdapter(
             return
         }
 
-        val interstitialAd = InterstitialAd(activity, adUnitId)
+        val interstitialAd = InterstitialAd(contextProvider.getContext(), adUnitId)
         this.interstitialAd = interstitialAd
 
         // Check if the newly constructed ad is already loaded

--- a/adapter-meta/src/main/java/io/cloudx/adapter/meta/MetaRewardedInterstitialAdapter.kt
+++ b/adapter-meta/src/main/java/io/cloudx/adapter/meta/MetaRewardedInterstitialAdapter.kt
@@ -1,6 +1,5 @@
 package io.cloudx.adapter.meta
 
-import android.app.Activity
 import androidx.annotation.Keep
 import com.facebook.ads.Ad
 import com.facebook.ads.AdError
@@ -14,6 +13,7 @@ import io.cloudx.sdk.internal.adapter.CloudXAdapterMetaData
 import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapter
 import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterFactory
 import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterListener
+import io.cloudx.sdk.internal.context.ContextProvider
 
 @Keep
 internal object RewardedInterstitialFactory :
@@ -21,7 +21,7 @@ internal object RewardedInterstitialFactory :
     CloudXAdapterMetaData by CloudXAdapterMetaData(AudienceNetworkAdsVersion) {
 
     override fun create(
-        activity: Activity,
+        contextProvider: ContextProvider,
         placementId: String,
         bidId: String,
         adm: String,
@@ -29,7 +29,7 @@ internal object RewardedInterstitialFactory :
         listener: CloudXRewardedInterstitialAdapterListener,
     ): Result<CloudXRewardedInterstitialAdapter, String> = Result.Success(
         MetaRewardedInterstitialAdapter(
-            activity,
+            contextProvider,
             adUnitId = adm,
             listener
         )
@@ -37,7 +37,7 @@ internal object RewardedInterstitialFactory :
 }
 
 internal class MetaRewardedInterstitialAdapter(
-    private val activity: Activity,
+    private val contextProvider: ContextProvider,
     private val adUnitId: String,
     private var listener: CloudXRewardedInterstitialAdapterListener?
 ) : CloudXRewardedInterstitialAdapter, CloudXAdLoadOperationAvailability by AlwaysReadyToLoadAd {
@@ -45,7 +45,7 @@ internal class MetaRewardedInterstitialAdapter(
     private var ad: RewardedInterstitialAd? = null
 
     override fun load() {
-        val ad = RewardedInterstitialAd(activity, adUnitId)
+        val ad = RewardedInterstitialAd(contextProvider.getContext(), adUnitId)
         this.ad = ad
 
         ad.loadAd(ad.buildLoadAdConfig().withAdListener(object : RewardedInterstitialAdListener {

--- a/adapter-mintegral/src/main/java/io/cloudx/adapter/mintegral/InterstitialAdapter.kt
+++ b/adapter-mintegral/src/main/java/io/cloudx/adapter/mintegral/InterstitialAdapter.kt
@@ -1,18 +1,18 @@
 package io.cloudx.adapter.mintegral
 
-import android.app.Activity
 import com.mbridge.msdk.newinterstitial.out.MBBidNewInterstitialHandler
 import com.mbridge.msdk.newinterstitial.out.NewInterstitialListener
 import com.mbridge.msdk.out.MBridgeIds
 import com.mbridge.msdk.out.RewardInfo
-import io.cloudx.sdk.internal.adapter.CloudXAdLoadOperationAvailability
 import io.cloudx.sdk.internal.adapter.AlwaysReadyToLoadAd
+import io.cloudx.sdk.internal.adapter.CloudXAdLoadOperationAvailability
 import io.cloudx.sdk.internal.adapter.CloudXAdapterError
 import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapter
 import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterListener
+import io.cloudx.sdk.internal.context.ContextProvider
 
 internal class InterstitialAdapter(
-    private val activity: Activity,
+    private val contextProvider: ContextProvider,
     private val placementId: String?,
     private val adUnitId: String,
     private val bidId: String?,
@@ -28,7 +28,7 @@ internal class InterstitialAdapter(
             return
         }
 
-        val adHandler = MBBidNewInterstitialHandler(activity, placementId, adUnitId)
+        val adHandler = MBBidNewInterstitialHandler(contextProvider.getContext(), placementId, adUnitId)
         this.adHandler = adHandler
 
         adHandler.setInterstitialVideoListener(object : NewInterstitialListener {

--- a/adapter-mintegral/src/main/java/io/cloudx/adapter/mintegral/InterstitialFactory.kt
+++ b/adapter-mintegral/src/main/java/io/cloudx/adapter/mintegral/InterstitialFactory.kt
@@ -1,15 +1,18 @@
 package io.cloudx.adapter.mintegral
 
-import android.app.Activity
-import io.cloudx.sdk.internal.adapter.*
 import io.cloudx.sdk.Result
+import io.cloudx.sdk.internal.adapter.CloudXAdapterMetaData
+import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapter
+import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterFactory
+import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterListener
+import io.cloudx.sdk.internal.context.ContextProvider
 
 internal object InterstitialFactory :
     CloudXInterstitialAdapterFactory,
     CloudXAdapterMetaData by CloudXAdapterMetaData(MintegralVersion) {
 
     override fun create(
-        activity: Activity,
+        contextProvider: ContextProvider,
         placementId: String,
         bidId: String,
         adm: String,
@@ -17,7 +20,7 @@ internal object InterstitialFactory :
         listener: CloudXInterstitialAdapterListener,
     ): Result<CloudXInterstitialAdapter, String> = Result.Success(
         InterstitialAdapter(
-            activity,
+            contextProvider,
             placementId = params?.placementId(),
             adUnitId = adm,
             bidId = params?.bidId(),

--- a/adapter-mintegral/src/main/java/io/cloudx/adapter/mintegral/RewardedInterstitialAdapter.kt
+++ b/adapter-mintegral/src/main/java/io/cloudx/adapter/mintegral/RewardedInterstitialAdapter.kt
@@ -1,18 +1,18 @@
 package io.cloudx.adapter.mintegral
 
-import android.app.Activity
 import com.mbridge.msdk.out.MBBidRewardVideoHandler
-import com.mbridge.msdk.out.RewardVideoListener
 import com.mbridge.msdk.out.MBridgeIds
 import com.mbridge.msdk.out.RewardInfo
-import io.cloudx.sdk.internal.adapter.CloudXAdLoadOperationAvailability
+import com.mbridge.msdk.out.RewardVideoListener
 import io.cloudx.sdk.internal.adapter.AlwaysReadyToLoadAd
+import io.cloudx.sdk.internal.adapter.CloudXAdLoadOperationAvailability
 import io.cloudx.sdk.internal.adapter.CloudXAdapterError
 import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapter
 import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterListener
+import io.cloudx.sdk.internal.context.ContextProvider
 
 internal class RewardedInterstitialAdapter(
-    private val activity: Activity,
+    private val contextProvider: ContextProvider,
     private val placementId: String?,
     private val adUnitId: String,
     private val bidId: String?,
@@ -28,7 +28,7 @@ internal class RewardedInterstitialAdapter(
             return
         }
 
-        val adHandler = MBBidRewardVideoHandler(activity, placementId, adUnitId)
+        val adHandler = MBBidRewardVideoHandler(contextProvider.getContext(), placementId, adUnitId)
         this.adHandler = adHandler
 
         adHandler.setRewardVideoListener(object : RewardVideoListener {

--- a/adapter-mintegral/src/main/java/io/cloudx/adapter/mintegral/RewardedInterstitialFactory.kt
+++ b/adapter-mintegral/src/main/java/io/cloudx/adapter/mintegral/RewardedInterstitialFactory.kt
@@ -1,15 +1,18 @@
 package io.cloudx.adapter.mintegral
 
-import android.app.Activity
-import io.cloudx.sdk.internal.adapter.*
 import io.cloudx.sdk.Result
+import io.cloudx.sdk.internal.adapter.CloudXAdapterMetaData
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapter
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterFactory
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterListener
+import io.cloudx.sdk.internal.context.ContextProvider
 
 internal object RewardedInterstitialFactory :
     CloudXRewardedInterstitialAdapterFactory,
     CloudXAdapterMetaData by CloudXAdapterMetaData(MintegralVersion) {
 
     override fun create(
-        activity: Activity,
+        contextProvider: ContextProvider,
         placementId: String,
         bidId: String,
         adm: String,
@@ -17,7 +20,7 @@ internal object RewardedInterstitialFactory :
         listener: CloudXRewardedInterstitialAdapterListener
     ): Result<CloudXRewardedInterstitialAdapter, String> = Result.Success(
         RewardedInterstitialAdapter(
-            activity,
+            contextProvider,
             placementId = params?.placementId(),
             adUnitId = adm,
             bidId = params?.bidId(),

--- a/adapter-testbidder/src/main/java/io/cloudx/adapter/testbidnetwork/InterstitialFactory.kt
+++ b/adapter-testbidder/src/main/java/io/cloudx/adapter/testbidnetwork/InterstitialFactory.kt
@@ -1,15 +1,18 @@
 package io.cloudx.adapter.testbidnetwork
 
-import android.app.Activity
-import io.cloudx.sdk.internal.adapter.*
 import io.cloudx.sdk.Result
+import io.cloudx.sdk.internal.adapter.CloudXAdapterMetaData
+import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapter
+import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterFactory
+import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterListener
+import io.cloudx.sdk.internal.context.ContextProvider
 
 internal object InterstitialFactory :
     CloudXInterstitialAdapterFactory,
     CloudXAdapterMetaData by CloudXAdapterMetaData("test-bid-network-version") {
 
     override fun create(
-        activity: Activity,
+        contextProvider: ContextProvider,
         placementId: String,
         bidId: String,
         adm: String,
@@ -17,7 +20,7 @@ internal object InterstitialFactory :
         listener: CloudXInterstitialAdapterListener,
     ): Result<CloudXInterstitialAdapter, String> = Result.Success(
         StaticBidInterstitial(
-            activity,
+            contextProvider.getContext(),
             adm,
             listener
         )

--- a/adapter-testbidder/src/main/java/io/cloudx/adapter/testbidnetwork/RewardedInterstitialFactory.kt
+++ b/adapter-testbidder/src/main/java/io/cloudx/adapter/testbidnetwork/RewardedInterstitialFactory.kt
@@ -1,15 +1,18 @@
 package io.cloudx.adapter.testbidnetwork
 
-import android.app.Activity
-import io.cloudx.sdk.internal.adapter.*
 import io.cloudx.sdk.Result
+import io.cloudx.sdk.internal.adapter.CloudXAdapterMetaData
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapter
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterFactory
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterListener
+import io.cloudx.sdk.internal.context.ContextProvider
 
 internal object RewardedInterstitialFactory :
     CloudXRewardedInterstitialAdapterFactory,
     CloudXAdapterMetaData by CloudXAdapterMetaData("test-bid-network-version") {
 
     override fun create(
-        activity: Activity,
+        contextProvider: ContextProvider,
         placementId: String,
         bidId: String,
         adm: String,
@@ -17,7 +20,7 @@ internal object RewardedInterstitialFactory :
         listener: CloudXRewardedInterstitialAdapterListener
     ): Result<CloudXRewardedInterstitialAdapter, String> = Result.Success(
         StaticBidRewardedInterstitial(
-            activity,
+            contextProvider.getContext(),
             adm,
             listener
         )

--- a/adapter-testbidder/src/main/java/io/cloudx/adapter/testbidnetwork/StaticBidInterstitial.kt
+++ b/adapter-testbidder/src/main/java/io/cloudx/adapter/testbidnetwork/StaticBidInterstitial.kt
@@ -1,22 +1,22 @@
 package io.cloudx.adapter.testbidnetwork
 
-import android.app.Activity
+import android.content.Context
 import io.cloudx.sdk.internal.FullscreenAd
-import io.cloudx.sdk.internal.adapter.CloudXAdLoadOperationAvailability
 import io.cloudx.sdk.internal.adapter.AlwaysReadyToLoadAd
+import io.cloudx.sdk.internal.adapter.CloudXAdLoadOperationAvailability
 import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapter
 import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterListener
 import io.cloudx.ts.staticrenderer.StaticFullscreenAd
 
 internal class StaticBidInterstitial(
-    activity: Activity,
+    context: Context,
     adm: String,
     listener: CloudXInterstitialAdapterListener
 ) : CloudXInterstitialAdapter,
     CloudXAdLoadOperationAvailability by AlwaysReadyToLoadAd {
 
     private val staticFullscreenAd = StaticFullscreenAd(
-        activity,
+        context,
         adm,
         object : FullscreenAd.Listener {
             override fun onLoad() {

--- a/adapter-testbidder/src/main/java/io/cloudx/adapter/testbidnetwork/StaticBidRewardedInterstitial.kt
+++ b/adapter-testbidder/src/main/java/io/cloudx/adapter/testbidnetwork/StaticBidRewardedInterstitial.kt
@@ -1,20 +1,22 @@
 package io.cloudx.adapter.testbidnetwork
 
-import io.cloudx.sdk.internal.adapter.*
-
-import android.app.Activity
+import android.content.Context
 import io.cloudx.sdk.internal.FullscreenAd
+import io.cloudx.sdk.internal.adapter.AlwaysReadyToLoadAd
+import io.cloudx.sdk.internal.adapter.CloudXAdLoadOperationAvailability
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapter
+import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterListener
 import io.cloudx.ts.staticrenderer.StaticFullscreenAd
 
 internal class StaticBidRewardedInterstitial(
-    activity: Activity,
+    context: Context,
     adm: String,
     listener: CloudXRewardedInterstitialAdapterListener
 ) : CloudXRewardedInterstitialAdapter,
     CloudXAdLoadOperationAvailability by AlwaysReadyToLoadAd {
 
     private val staticFullscreenAd = StaticFullscreenAd(
-        activity,
+        context,
         adm,
         object : FullscreenAd.Listener {
             override fun onLoad() {

--- a/adapter-testbidder/src/main/java/io/cloudx/ts/staticrenderer/ExternalLinkHandler.kt
+++ b/adapter-testbidder/src/main/java/io/cloudx/ts/staticrenderer/ExternalLinkHandler.kt
@@ -1,9 +1,6 @@
 package io.cloudx.ts.staticrenderer
 
-import android.app.Activity
 import android.content.Context
-import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 
@@ -11,9 +8,9 @@ fun interface ExternalLinkHandler {
     operator fun invoke(uri: String): Boolean
 }
 
-class ExternalLinkHandlerImpl(private val activity: Activity): ExternalLinkHandler {
+class ExternalLinkHandlerImpl(private val context: Context): ExternalLinkHandler {
     override fun invoke(uri: String): Boolean {
-        return activity.tryStartCustomTabs(uri)
+        return context.tryStartCustomTabs(uri)
     }
 }
 

--- a/adapter-testbidder/src/main/java/io/cloudx/ts/staticrenderer/StaticAdActivity.kt
+++ b/adapter-testbidder/src/main/java/io/cloudx/ts/staticrenderer/StaticAdActivity.kt
@@ -1,10 +1,8 @@
 package io.cloudx.ts.staticrenderer
 
-import android.app.Activity
+import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import android.view.Gravity
 import android.view.View.VISIBLE
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
@@ -14,7 +12,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.widget.AppCompatButton
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -107,10 +104,12 @@ internal class StaticAdActivity : ComponentActivity() {
         }
 
         // Doesn't support parallel calls, not required though.
-        suspend fun show(activity: Activity, staticWebView: StaticWebView) {
+        suspend fun show(context: Context, staticWebView: StaticWebView) {
             try {
                 Companion.staticWebView = staticWebView
-                activity.startActivity(Intent(activity, StaticAdActivity::class.java))
+                val intent = Intent(context, StaticAdActivity::class.java)
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                context.startActivity(intent)
 
                 dismiss.first { it }
 

--- a/adapter-testbidder/src/main/java/io/cloudx/ts/staticrenderer/StaticFullscreenAd.kt
+++ b/adapter-testbidder/src/main/java/io/cloudx/ts/staticrenderer/StaticFullscreenAd.kt
@@ -1,6 +1,7 @@
 package io.cloudx.ts.staticrenderer
 
-import android.app.Activity
+import android.content.Context
+import io.cloudx.sdk.internal.FullscreenAd
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -8,21 +9,20 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import io.cloudx.sdk.internal.FullscreenAd
 
 fun StaticFullscreenAd(
-    activity: Activity,
+    context: Context,
     adm: String,
     listener: FullscreenAd.Listener?
 ): FullscreenAd<FullscreenAd.Listener> =
     StaticFullscreenAdImpl(
-        activity,
+        context,
         adm,
         listener
     )
 
 private class StaticFullscreenAdImpl(
-    private val activity: Activity,
+    private val context: Context,
     private val adm: String,
     override var listener: FullscreenAd.Listener?
 ) : FullscreenAd<FullscreenAd.Listener> {
@@ -30,7 +30,7 @@ private class StaticFullscreenAdImpl(
     private val scope = CoroutineScope(Dispatchers.Main)
 
     private val staticWebView: StaticWebView by lazy {
-        StaticWebView(activity, ExternalLinkHandlerImpl(activity))
+        StaticWebView(context, ExternalLinkHandlerImpl(context))
     }
 
     override fun load() {
@@ -58,7 +58,7 @@ private class StaticFullscreenAdImpl(
             }
 
             try {
-                StaticAdActivity.show(activity, staticWebView)
+                StaticAdActivity.show(context, staticWebView)
             } finally {
                 listener?.onComplete()
                 listener?.onHide()

--- a/app/src/main/java/io/cloudx/demo/demoapp/InterstitialFragment.kt
+++ b/app/src/main/java/io/cloudx/demo/demoapp/InterstitialFragment.kt
@@ -7,7 +7,6 @@ import io.cloudx.sdk.CloudXInterstitialListener
 class InterstitialFragment : FullPageAdFragment() {
 
     override fun createAd(listener: CloudXAdListener) = CloudX.createInterstitial(
-        requireActivity(),
         placementName,
         object : CloudXInterstitialListener, CloudXAdListener by listener {}
     )

--- a/app/src/main/java/io/cloudx/demo/demoapp/RewardedFragment.kt
+++ b/app/src/main/java/io/cloudx/demo/demoapp/RewardedFragment.kt
@@ -9,7 +9,6 @@ import io.cloudx.sdk.internal.CloudXLogger
 class RewardedFragment : FullPageAdFragment() {
 
     override fun createAd(listener: CloudXAdListener) = CloudX.createRewardedInterstitial(
-        requireActivity(),
         placementName,
         object : RewardedInterstitialListener, CloudXAdListener by listener {
             override fun onUserRewarded(cloudXAd: CloudXAd) {

--- a/sdk/src/main/java/io/cloudx/sdk/CloudX.kt
+++ b/sdk/src/main/java/io/cloudx/sdk/CloudX.kt
@@ -200,7 +200,6 @@ object CloudX {
      * 4. call [show()][CloudXFullscreenAd.show] when you're ready to display an ad; then wait for [onAdShowSuccess()][CloudXAdListener.onAdDisplayed] or [onAdShowFailed()][CloudXAdListener.onAdDisplayFailed] event;
      * 5. Whenever parent Activity or Fragment is destroyed; or when ads are not required anymore - release ad instance resources via calling [destroy()][Destroyable.destroy]
      *
-     * @param activity activity instance to which [CloudXInterstitialAd] ad instance is going to be attached to.
      * @param placementName identifier of CloudX placement setup on the dashboard.
      *
      * _Once SDK is [initialized][initialize] it knows which placement names are valid for ad creation_
@@ -209,15 +208,12 @@ object CloudX {
      */
     @JvmStatic
     fun createInterstitial(
-        activity: Activity,
         placementName: String,
         listener: CloudXInterstitialListener?
     ): CloudXInterstitialAd? {
         initializationService?.metricsTrackerNew?.trackMethodCall(MetricsType.Method.CreateInterstitial)
         return initializationService?.adFactory?.createInterstitial(
-            AdFactory.CreateAdParams(
-                activity, placementName, listener
-            )
+            AdFactory.CreateAdParams(placementName, listener)
         )
     }
 
@@ -237,7 +233,6 @@ object CloudX {
      * 4. call [show()][CloudXFullscreenAd.show] when you're ready to display an ad; then wait for [onAdShowSuccess()][CloudXAdListener.onAdDisplayed] or [onAdShowFailed()][CloudXAdListener.onAdDisplayFailed] event;
      * 5. Whenever parent Activity or Fragment is destroyed; or when ads are not required anymore - release ad instance resources via calling [destroy()][Destroyable.destroy]
      *
-     * @param activity activity instance to which [CloudXRewardedAd] ad instance is going to be attached to.
      * @param placementName identifier of CloudX placement setup on the dashboard.
      *
      * _Once SDK is [initialized][initialize] it knows which placement names are valid for ad creation_
@@ -246,15 +241,12 @@ object CloudX {
      */
     @JvmStatic
     fun createRewardedInterstitial(
-        activity: Activity,
         placementName: String,
         listener: RewardedInterstitialListener?
     ): CloudXRewardedAd? {
         initializationService?.metricsTrackerNew?.trackMethodCall(MetricsType.Method.CreateRewarded)
         return initializationService?.adFactory?.createRewarded(
-            AdFactory.CreateAdParams(
-                activity, placementName, listener
-            )
+            AdFactory.CreateAdParams(placementName, listener)
         )
     }
 

--- a/sdk/src/main/java/io/cloudx/sdk/CloudXAdView.kt
+++ b/sdk/src/main/java/io/cloudx/sdk/CloudXAdView.kt
@@ -11,6 +11,7 @@ import android.widget.ImageButton
 import android.widget.ImageView
 import androidx.core.view.setPadding
 import io.cloudx.sdk.internal.AdViewSize
+import io.cloudx.sdk.internal.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel

--- a/sdk/src/main/java/io/cloudx/sdk/CloudXInterstitialAd.kt
+++ b/sdk/src/main/java/io/cloudx/sdk/CloudXInterstitialAd.kt
@@ -1,17 +1,18 @@
 package io.cloudx.sdk
 
-import android.app.Activity
 import io.cloudx.sdk.internal.AdNetwork
 import io.cloudx.sdk.internal.AdType
-import io.cloudx.sdk.internal.adapter.*
+import io.cloudx.sdk.internal.adapter.CloudXAdapterBidRequestExtrasProvider
+import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterFactory
 import io.cloudx.sdk.internal.bid.BidApi
 import io.cloudx.sdk.internal.bid.BidRequestProvider
 import io.cloudx.sdk.internal.cdp.CdpApi
 import io.cloudx.sdk.internal.common.service.AppLifecycleService
 import io.cloudx.sdk.internal.connectionstatus.ConnectionStatusService
-import io.cloudx.sdk.internal.core.ad.source.bid.*
 import io.cloudx.sdk.internal.core.ad.adapter_delegate.InterstitialAdapterDelegate
 import io.cloudx.sdk.internal.core.ad.adapter_delegate.InterstitialAdapterDelegateEvent
+import io.cloudx.sdk.internal.core.ad.source.bid.BidAdSource
+import io.cloudx.sdk.internal.core.ad.source.bid.BidInterstitialSource
 import io.cloudx.sdk.internal.imp_tracker.EventTracker
 import io.cloudx.sdk.internal.imp_tracker.metrics.MetricsTrackerNew
 
@@ -21,7 +22,6 @@ interface CloudXInterstitialAd : CloudXFullscreenAd
 interface CloudXInterstitialListener : CloudXAdListener
 
 internal fun Interstitial(
-    activity: Activity,
     placementId: String,
     placementName: String,
     cacheSize: Int,
@@ -41,13 +41,11 @@ internal fun Interstitial(
 ): CloudXInterstitialAd {
 
     val bidRequestProvider = BidRequestProvider(
-        activity,
         bidRequestExtrasProviders
     )
 
     val bidSource =
         BidInterstitialSource(
-            activity,
             bidFactories,
             placementId,
             placementName,

--- a/sdk/src/main/java/io/cloudx/sdk/CloudXRewardedAd.kt
+++ b/sdk/src/main/java/io/cloudx/sdk/CloudXRewardedAd.kt
@@ -1,6 +1,5 @@
 package io.cloudx.sdk
 
-import android.app.Activity
 import io.cloudx.sdk.internal.AdNetwork
 import io.cloudx.sdk.internal.AdType
 import io.cloudx.sdk.internal.adapter.CloudXAdapterBidRequestExtrasProvider
@@ -10,10 +9,10 @@ import io.cloudx.sdk.internal.bid.BidRequestProvider
 import io.cloudx.sdk.internal.cdp.CdpApi
 import io.cloudx.sdk.internal.common.service.AppLifecycleService
 import io.cloudx.sdk.internal.connectionstatus.ConnectionStatusService
-import io.cloudx.sdk.internal.core.ad.source.bid.BidAdSource
-import io.cloudx.sdk.internal.core.ad.source.bid.BidRewardedInterstitialSource
 import io.cloudx.sdk.internal.core.ad.adapter_delegate.RewardedInterstitialAdapterDelegate
 import io.cloudx.sdk.internal.core.ad.adapter_delegate.RewardedInterstitialAdapterDelegateEvent
+import io.cloudx.sdk.internal.core.ad.source.bid.BidAdSource
+import io.cloudx.sdk.internal.core.ad.source.bid.BidRewardedInterstitialSource
 import io.cloudx.sdk.internal.imp_tracker.EventTracker
 import io.cloudx.sdk.internal.imp_tracker.metrics.MetricsTrackerNew
 
@@ -30,7 +29,6 @@ interface RewardedInterstitialListener : CloudXAdListener {
 }
 
 internal fun RewardedInterstitial(
-    activity: Activity,
     placementId: String,
     placementName: String,
     cacheSize: Int,
@@ -50,13 +48,11 @@ internal fun RewardedInterstitial(
 ): CloudXRewardedAd {
 
     val bidRequestProvider = BidRequestProvider(
-        activity,
         bidRequestExtrasProviders
     )
 
     val bidSource =
         BidRewardedInterstitialSource(
-            activity,
             bidFactories,
             placementId,
             placementName,

--- a/sdk/src/main/java/io/cloudx/sdk/internal/ad_banner/BannerManager.kt
+++ b/sdk/src/main/java/io/cloudx/sdk/internal/ad_banner/BannerManager.kt
@@ -76,7 +76,6 @@ internal fun BannerManager(
 ): BannerManager {
 
     val bidRequestProvider = BidRequestProvider(
-        activity,
         bidRequestExtrasProviders
     )
 

--- a/sdk/src/main/java/io/cloudx/sdk/internal/adapter/CloudXInterstitialAdapter.kt
+++ b/sdk/src/main/java/io/cloudx/sdk/internal/adapter/CloudXInterstitialAdapter.kt
@@ -1,13 +1,13 @@
 package io.cloudx.sdk.internal.adapter
 
-import android.app.Activity
 import io.cloudx.sdk.Destroyable
 import io.cloudx.sdk.Result
+import io.cloudx.sdk.internal.context.ContextProvider
 
 interface CloudXInterstitialAdapterFactory : CloudXAdapterMetaData {
 
     fun create(
-        activity: Activity,
+        contextProvider: ContextProvider,
         placementId: String,
         bidId: String,
         adm: String,

--- a/sdk/src/main/java/io/cloudx/sdk/internal/adapter/CloudXRewardedInterstitialAdapter.kt
+++ b/sdk/src/main/java/io/cloudx/sdk/internal/adapter/CloudXRewardedInterstitialAdapter.kt
@@ -1,13 +1,13 @@
 package io.cloudx.sdk.internal.adapter
 
-import android.app.Activity
 import io.cloudx.sdk.Destroyable
 import io.cloudx.sdk.Result
+import io.cloudx.sdk.internal.context.ContextProvider
 
 interface CloudXRewardedInterstitialAdapterFactory : CloudXAdapterMetaData {
 
     fun create(
-        activity: Activity,
+        contextProvider: ContextProvider,
         placementId: String,
         bidId: String,
         adm: String,

--- a/sdk/src/main/java/io/cloudx/sdk/internal/adfactory/AdFactory.kt
+++ b/sdk/src/main/java/io/cloudx/sdk/internal/adfactory/AdFactory.kt
@@ -29,18 +29,17 @@ internal interface AdFactory {
     fun createRewarded(params: CreateAdParams<RewardedInterstitialListener>): CloudXRewardedAd?
 
     open class CreateAdParams<T>(
-        val activity: Activity,
         val placementName: String,
         val listener: T?
     )
 
     class CreateBannerParams(
         val adType: AdType,
-        activity: Activity,
+        val activity: Activity,
         placementName: String,
         listener: CloudXAdViewListener?,
     ) : CreateAdParams<CloudXAdViewListener>(
-        activity, placementName, listener
+        placementName, listener
     )
 }
 

--- a/sdk/src/main/java/io/cloudx/sdk/internal/adfactory/AdFactoryImpl.kt
+++ b/sdk/src/main/java/io/cloudx/sdk/internal/adfactory/AdFactoryImpl.kt
@@ -135,7 +135,6 @@ internal class AdFactoryImpl(
         val bidApi = createBidApi(placement.bidResponseTimeoutMillis)
 
         return Interstitial(
-            params.activity,
             placementId = placement.id,
             placementName = placement.name,
             cacheSize = config.precacheSize,
@@ -168,7 +167,6 @@ internal class AdFactoryImpl(
         val bidApi = createBidApi(placement.bidResponseTimeoutMillis)
 
         return RewardedInterstitial(
-            params.activity,
             placementId = placement.id,
             placementName = placement.name,
             cacheSize = config.precacheSize,

--- a/sdk/src/main/java/io/cloudx/sdk/internal/bid/BidRequestProvider.kt
+++ b/sdk/src/main/java/io/cloudx/sdk/internal/bid/BidRequestProvider.kt
@@ -1,9 +1,10 @@
 package io.cloudx.sdk.internal.bid
 
-import android.content.Context
 import io.cloudx.sdk.BuildConfig
 import io.cloudx.sdk.internal.AdNetwork
 import io.cloudx.sdk.internal.AdType
+import io.cloudx.sdk.internal.ApplicationContext
+import io.cloudx.sdk.internal.PlacementLoopIndexTracker
 import io.cloudx.sdk.internal.adapter.CloudXAdapterBidRequestExtrasProvider
 import io.cloudx.sdk.internal.appinfo.AppInfoProvider
 import io.cloudx.sdk.internal.connectionstatus.ConnectionStatusService
@@ -12,7 +13,6 @@ import io.cloudx.sdk.internal.gaid.GAIDProvider
 import io.cloudx.sdk.internal.httpclient.UserAgentProvider
 import io.cloudx.sdk.internal.privacy.PrivacyService
 import io.cloudx.sdk.internal.screen.ScreenService
-import io.cloudx.sdk.internal.PlacementLoopIndexTracker
 import org.json.JSONObject
 
 // TODO. Separate Json conversion logic from business logic.
@@ -40,14 +40,13 @@ internal fun BidRequestProvider.Params.withEffectivePlacementId(): String {
 
 
 internal fun BidRequestProvider(
-    context: Context,
     bidRequestExtrasProviders: Map<AdNetwork, CloudXAdapterBidRequestExtrasProvider>
 ) = BidRequestProviderImpl(
-    context.applicationContext,
+    ApplicationContext(),
     BuildConfig.SDK_VERSION_NAME,
     AppInfoProvider(),
     DeviceInfoProvider(),
-    ScreenService(context),
+    ScreenService(ApplicationContext()),
     ConnectionStatusService(),
     UserAgentProvider(),
     GAIDProvider(),

--- a/sdk/src/main/java/io/cloudx/sdk/internal/context/ContextProvider.kt
+++ b/sdk/src/main/java/io/cloudx/sdk/internal/context/ContextProvider.kt
@@ -1,0 +1,34 @@
+package io.cloudx.sdk.internal.context
+
+import android.app.Activity
+import android.content.Context
+import io.cloudx.sdk.internal.ApplicationContext
+import io.cloudx.sdk.internal.common.service.ActivityLifecycleService
+
+interface ContextProvider {
+    fun getContext(): Context
+    fun getActivityOrNull(): Activity?
+}
+
+fun ContextProvider(): ContextProvider = LazySingleInstance
+
+private val LazySingleInstance by lazy {
+    ContextProviderImpl(
+        applicationContext = ApplicationContext(),
+        activityLifecycleService = ActivityLifecycleService()
+    )
+}
+
+private class ContextProviderImpl(
+    private val applicationContext: Context,
+    private val activityLifecycleService: ActivityLifecycleService
+) : ContextProvider {
+    
+    override fun getContext(): Context {
+        return getActivityOrNull() ?: applicationContext
+    }
+    
+    override fun getActivityOrNull(): Activity? {
+        return activityLifecycleService.currentResumedActivity.value
+    }
+}

--- a/sdk/src/main/java/io/cloudx/sdk/internal/core/ad/source/bid/BidInterstitialSource.kt
+++ b/sdk/src/main/java/io/cloudx/sdk/internal/core/ad/source/bid/BidInterstitialSource.kt
@@ -1,6 +1,5 @@
 package io.cloudx.sdk.internal.core.ad.source.bid
 
-import android.app.Activity
 import io.cloudx.sdk.Result
 import io.cloudx.sdk.internal.AdNetwork
 import io.cloudx.sdk.internal.AdType
@@ -8,16 +7,16 @@ import io.cloudx.sdk.internal.adapter.CloudXInterstitialAdapterFactory
 import io.cloudx.sdk.internal.bid.BidApi
 import io.cloudx.sdk.internal.bid.BidRequestProvider
 import io.cloudx.sdk.internal.cdp.CdpApi
+import io.cloudx.sdk.internal.context.ContextProvider
+import io.cloudx.sdk.internal.core.ad.adapter_delegate.InterstitialAdapterDelegate
 import io.cloudx.sdk.internal.core.ad.source.adapterLoggingDecoration
 import io.cloudx.sdk.internal.core.ad.source.baseAdDecoration
 import io.cloudx.sdk.internal.core.ad.source.bidAdDecoration
 import io.cloudx.sdk.internal.core.ad.source.decorate
-import io.cloudx.sdk.internal.core.ad.adapter_delegate.InterstitialAdapterDelegate
 import io.cloudx.sdk.internal.imp_tracker.EventTracker
 import io.cloudx.sdk.internal.imp_tracker.metrics.MetricsTrackerNew
 
 internal fun BidInterstitialSource(
-    activity: Activity,
     factories: Map<AdNetwork, CloudXInterstitialAdapterFactory>,
     placementId: String,
     placementName: String,
@@ -66,7 +65,7 @@ internal fun BidInterstitialSource(
         ) { listener ->
             // TODO. IMPORTANT. Explicit Result cast isn't "cool", even though there's try catch somewhere.
             (factories[adNetwork]?.create(
-                activity,
+                ContextProvider(),
                 placementId,
                 bidId,
                 adm,

--- a/sdk/src/main/java/io/cloudx/sdk/internal/core/ad/source/bid/BidRewardedInterstitialSource.kt
+++ b/sdk/src/main/java/io/cloudx/sdk/internal/core/ad/source/bid/BidRewardedInterstitialSource.kt
@@ -1,6 +1,5 @@
 package io.cloudx.sdk.internal.core.ad.source.bid
 
-import android.app.Activity
 import io.cloudx.sdk.Result
 import io.cloudx.sdk.internal.AdNetwork
 import io.cloudx.sdk.internal.AdType
@@ -8,16 +7,16 @@ import io.cloudx.sdk.internal.adapter.CloudXRewardedInterstitialAdapterFactory
 import io.cloudx.sdk.internal.bid.BidApi
 import io.cloudx.sdk.internal.bid.BidRequestProvider
 import io.cloudx.sdk.internal.cdp.CdpApi
+import io.cloudx.sdk.internal.context.ContextProvider
+import io.cloudx.sdk.internal.core.ad.adapter_delegate.RewardedInterstitialAdapterDelegate
 import io.cloudx.sdk.internal.core.ad.source.adapterLoggingDecoration
 import io.cloudx.sdk.internal.core.ad.source.baseAdDecoration
 import io.cloudx.sdk.internal.core.ad.source.bidAdDecoration
 import io.cloudx.sdk.internal.core.ad.source.decorate
-import io.cloudx.sdk.internal.core.ad.adapter_delegate.RewardedInterstitialAdapterDelegate
 import io.cloudx.sdk.internal.imp_tracker.EventTracker
 import io.cloudx.sdk.internal.imp_tracker.metrics.MetricsTrackerNew
 
 internal fun BidRewardedInterstitialSource(
-    activity: Activity,
     factories: Map<AdNetwork, CloudXRewardedInterstitialAdapterFactory>,
     placementId: String,
     placementName: String,
@@ -66,7 +65,7 @@ internal fun BidRewardedInterstitialSource(
         ) { listener ->
             // TODO. IMPORTANT. Explicit Result cast isn't "cool", even though there's try catch somewhere.
             (factories[network]?.create(
-                activity,
+                ContextProvider(),
                 placementId,
                 bidId,
                 adm,

--- a/sdk/src/main/java/io/cloudx/sdk/internal/initialization/InitializationServiceImpl.kt
+++ b/sdk/src/main/java/io/cloudx/sdk/internal/initialization/InitializationServiceImpl.kt
@@ -249,7 +249,6 @@ internal class InitializationServiceImpl(
             appKey = appKey
         )
         val bidRequestProvider = BidRequestProvider(
-            context,
             emptyMap()
         )
         val bidRequestParamsJson = bidRequestProvider.invoke(bidRequestParams, eventId)

--- a/sdk/src/main/samples/kotlin/io/cloudx/sdk/samples/CloudXSamples.kt
+++ b/sdk/src/main/samples/kotlin/io/cloudx/sdk/samples/CloudXSamples.kt
@@ -106,10 +106,9 @@ internal fun cloudXCreateAdView(activity: Activity, frameLayout: FrameLayout) {
     }
 }
 
-internal fun createInterstitial(activity: Activity, placementName: String) {
+internal fun createInterstitial(placementName: String) {
     var ad: CloudXInterstitialAd? = null
     ad = CloudX.createInterstitial(
-        activity,
         placementName,
         // Track events if necessary.
         object : CloudXInterstitialListener {
@@ -171,10 +170,9 @@ internal fun createInterstitial(activity: Activity, placementName: String) {
     ad?.destroy()
 }
 
-internal fun createRewarded(activity: Activity, placementName: String) {
+internal fun createRewarded(placementName: String) {
     var ad: CloudXRewardedAd? = null
     ad = CloudX.createRewardedInterstitial(
-        activity,
         placementName,
         // Track events if necessary.
         object : RewardedInterstitialListener {

--- a/sdk/src/test/java/io/cloudx/sdk/internal/bid/BidApiTest.kt
+++ b/sdk/src/test/java/io/cloudx/sdk/internal/bid/BidApiTest.kt
@@ -1,6 +1,5 @@
 package io.cloudx.sdk.internal.bid
 
-import android.app.Activity
 import io.cloudx.sdk.Result
 import io.cloudx.sdk.RoboMockkTest
 import io.cloudx.sdk.internal.AdType
@@ -12,7 +11,6 @@ import io.cloudx.sdk.mocks.MockScreenService
 import io.cloudx.sdk.mocks.MockUserAgentProvider
 import io.mockk.InternalPlatformDsl.toStr
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import io.mockk.mockkStatic
 import kotlinx.coroutines.test.runTest
 import org.junit.Ignore
@@ -20,10 +18,6 @@ import org.junit.Test
 import java.util.UUID
 
 class BidApiTest: RoboMockkTest() {
-
-    @MockK
-    private lateinit var activity: Activity
-
     private lateinit var provideBidRequest: BidRequestProvider
     private lateinit var bidApi: BidApi
 
@@ -48,7 +42,7 @@ class BidApiTest: RoboMockkTest() {
             } returns MockUserAgentProvider
         }
 
-        provideBidRequest = BidRequestProvider(activity, mapOf())
+        provideBidRequest = BidRequestProvider(mapOf())
         bidApi = BidApi(
             endpointUrl = "https://ads.cloudx.io/openrtb2/auction",
             10000L


### PR DESCRIPTION
- Banners have a hard dependency on activities to detect visibility
- I think this is ok because banners are typically tied to a single activity and are not prefetched or cached
- Pubs typically fetch full screen ads in advance so they shouldn't be tied to an Activity